### PR TITLE
Performance optimisations

### DIFF
--- a/pyblish_rpc/client.py
+++ b/pyblish_rpc/client.py
@@ -19,7 +19,7 @@ try:
     import xmlrpclib
 except ImportError:
     # Python 3
-    import xmlrpc.server as xmlrpclib    
+    import xmlrpc.server as xmlrpclib
 
 
 import pyblish.api

--- a/pyblish_rpc/formatting.py
+++ b/pyblish_rpc/formatting.py
@@ -113,12 +113,6 @@ def format_error(error):
 def format_data(data):
     """Serialise instance/context data
 
-    Given an arbitrary dictionary of Python object,
-    return a JSON-compatible dictionary.
-
-    Note that all keys are cast to string and that values
-    not compatible with JSON are replaced with "Not supported".
-
     Arguments:
         data (dict): Data to serialise
 
@@ -127,22 +121,16 @@ def format_data(data):
 
     """
 
-    formatted = dict()
-
-    for key, value in data.iteritems():
-        try:
-            key = str(key)
-        except:
-            continue
-
-        try:
-            json.dumps(value)
-        except:
-            value = "Not supported"
-
-        formatted[key] = value
-
-    return formatted
+    # These are the only data members
+    # accessible from the client
+    return {key: data[key] for key in (
+        "name",
+        "label",
+        "family",
+        "families",
+        "publish",
+        ) if key in data
+    }
 
 
 def format_instance(instance):

--- a/pyblish_rpc/formatting.py
+++ b/pyblish_rpc/formatting.py
@@ -123,14 +123,14 @@ def format_data(data):
 
     # These are the only data members
     # accessible from the client
-    return {key: data[key] for key in (
+    return dict((key, data[key]) for key in (
         "name",
         "label",
         "family",
         "families",
         "publish",
         ) if key in data
-    }
+    )
 
 
 def format_instance(instance):

--- a/pyblish_rpc/mocking.py
+++ b/pyblish_rpc/mocking.py
@@ -499,6 +499,7 @@ class ValidateWithHyperlinks(pyblish.api.Validator):
 
 
 class LongRunningCollector(pyblish.api.Collector):
+    """I will take at least 2 seconds..."""
     def process(self, context):
         self.log.info("Sleeping for 2 seconds..")
         time.sleep(2)
@@ -506,21 +507,26 @@ class LongRunningCollector(pyblish.api.Collector):
 
 
 class LongRunningValidator(pyblish.api.Validator):
+    """I will take at least 2 seconds..."""
     def process(self, context):
         self.log.info("Sleeping for 2 seconds..")
         time.sleep(2)
         self.log.info("Good morning")
 
 
-class CollectSorting(pyblish.api.Collector):
-
-    order = pyblish.api.Collector.order + 0.499
+class RearrangingPlugin(pyblish.api.ContextPlugin):
+    """Sort plug-ins by family, and then reverse it"""
+    order = pyblish.api.CollectorOrder + 0.2
 
     def process(self, context):
+        self.log.info("Reversing instances in the context..")
+        context[:] = sorted(
+            context,
+            key=lambda i: i.data["family"],
+            reverse=True
+        )
+        self.log.info("Reversed!")
 
-        context[:] = sorted(context,
-                            key=lambda instance: (instance.data("family"),
-                                                  instance.data("name")))
 
 instances = [
     {
@@ -626,7 +632,8 @@ plugins = [
 
     LongRunningCollector,
     LongRunningValidator,
-    CollectSorting,
+
+    RearrangingPlugin
 ]
 
 pyblish.api.sort_plugins(plugins)

--- a/pyblish_rpc/mocking.py
+++ b/pyblish_rpc/mocking.py
@@ -528,6 +528,15 @@ class RearrangingPlugin(pyblish.api.ContextPlugin):
         self.log.info("Reversed!")
 
 
+class InactiveInstanceCollectorPlugin(pyblish.api.InstancePlugin):
+    """Special case of an InstancePlugin running as a Collector"""
+    order = pyblish.api.CollectorOrder + 0.1
+    active = False
+
+    def process(self, instance):
+        raise TypeError("I shouldn't have run in the first place")
+
+
 instances = [
     {
         "name": "Peter01",
@@ -633,7 +642,8 @@ plugins = [
     LongRunningCollector,
     LongRunningValidator,
 
-    RearrangingPlugin
+    RearrangingPlugin,
+    InactiveInstanceCollectorPlugin
 ]
 
 pyblish.api.sort_plugins(plugins)

--- a/pyblish_rpc/version.py
+++ b/pyblish_rpc/version.py
@@ -1,7 +1,7 @@
 
 VERSION_MAJOR = 0
 VERSION_MINOR = 2
-VERSION_PATCH = 0
+VERSION_PATCH = 1
 
 version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
 version = '%i.%i.%i' % version_info

--- a/tests/test_mocking.py
+++ b/tests/test_mocking.py
@@ -1,6 +1,7 @@
 """Test mocking plug-ins"""
 
 import pyblish.api
+import pyblish.logic
 import pyblish.plugin
 
 import pyblish_rpc.service
@@ -14,8 +15,10 @@ def test_plugins(sleep):
     """Trigger all plug-ins"""
     context = pyblish.api.Context()
 
-    for plugin in pyblish_rpc.mocking.plugins:
-        pyblish.plugin.process(plugin, context)
+    for plugin, instance in pyblish.logic.Iterator(
+            pyblish_rpc.mocking.plugins, context):
+        print("Running %s" % plugin)
+        pyblish.plugin.process(plugin, context, instance)
 
 
 @mock.patch("time.sleep")


### PR DESCRIPTION
This is a major performance improvement; when sending things across to QML, it previously serialised and sent *all* your data once every reset and once every process - meaning lots and lots of times in every publish - including any heavy dictionary or other large data structures. Now it only send across a tiny spec of relevant information for visualisation.

For debugging, the new collector reordering plug-in also manifests itself visually by reversing the order of families.