### PR TITLE
Restore context information from previous optimisation

### DIFF
--- a/pyblish_rpc/formatting.py
+++ b/pyblish_rpc/formatting.py
@@ -124,11 +124,23 @@ def format_data(data):
     # These are the only data members
     # accessible from the client
     return dict((key, data[key]) for key in (
+
+        # Essential data from each instance
         "name",
         "label",
         "family",
         "families",
         "publish",
+
+        # Provided by service.py
+        "host",
+        "port",
+        "user",
+        "connectTime",
+        "pyblishServerVersion",
+        "pyblishRPCVersion",
+        "pythonVersion"
+
         ) if key in data
     )
 


### PR DESCRIPTION
The Context info in the QML Terminal got lost in the previous optimisation.